### PR TITLE
Update scale2h.php

### DIFF
--- a/elements/snippets/scale2h.php
+++ b/elements/snippets/scale2h.php
@@ -47,7 +47,7 @@ $ny = $new_h;
         
 $modx->log(\modX::LOG_LEVEL_INFO,'New asset dimensions calculated: '.$nx, $ny,'','scale2h Output Filer');
 
-$modx->setPlaceholder('asset_id.width', $ny);
+$modx->setPlaceholder('asset_id.width', $nx);
 return $Asset->getThumbnailURL($nx, $ny);
 
 


### PR DESCRIPTION
correct the variable being returned as the asset_id.width placeholder. line 50. previously was using the $ny variable, should be using the $nx variable.