### PR TITLE
fix for UTF-8 conversion of non-English lexicons

### DIFF
--- a/controllers/PageController.php
+++ b/controllers/PageController.php
@@ -234,10 +234,10 @@ class PageController extends BaseController {
                 MODx.on("ready",function() {
                     console.log("[assman] on ready...");
                     MODx.addTab("modx-resource-tabs",{
-                        title: '.json_encode(utf8_encode($title)).',
+                        title: '.json_encode(mb_convert_encoding($title,'UTF-8','auto')).',
                         id: "assets-resource-tab",
                         width: "95%",
-                        html: '.json_encode(utf8_encode($out)).'
+                        html: '.json_encode(mb_convert_encoding($out,'UTF-8','auto')).'
                     });
                     if (inited==0) {
                         page_init();
@@ -254,10 +254,10 @@ class PageController extends BaseController {
                 MODx.on("ready",function() {
                     console.log("[assman] on ready...");
                     MODx.addTab("modx-resource-tabs",{
-                        title: '.json_encode(utf8_encode($title)).',
+                        title: '.json_encode(mb_convert_encoding($title,'UTF-8','auto')).',
                         id: "assets-resource-tab",
                         width: "95%",
-                        html: '.json_encode(utf8_encode($out)).'
+                        html: '.json_encode(mb_convert_encoding($out,'UTF-8','auto')).'
                     });
                 });                
             </script>');


### PR DESCRIPTION
this conversion method seems to be more reliable than original version (I've had issues with UTF-8 encoded "ru" lexicon strings)