### PR TITLE
Update settings for 1.2 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
     },    
     "extra": {
         "repoman": "1.0",
-        "package_name": "Asset Manager",
+        "package_name": "AssetManager",
         "namespace": "assman",
-        "version": "1.1.1",
+        "version": "1.2.0",
         "release": "pl",
         "category":"Asset Manager",
         "core_path": "",

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,5 +1,18 @@
 Changelog for Asset Manager
 
+Version 1.2.0
+-------------
+- Use stricter CSS
+- Add default group
+- Add target="_blank" to outgoing links in manager
+- Remove conflicting css
+- Use font awesome icons
+- Count assets in getPageAssets after retrieving
+- Add assman.skip_templates setting to determine templates to not initiate the asset manager on
+- Fix fatal js error when jquery has conflicts [#60]
+- Clean up builds and .DS_Store files from repo
+- Fix broken components
+
 Version 1.1.0
 -------------
 


### PR DESCRIPTION
Had to change the package_name for it to generate a package name without spaces that would work from the package manager. And collected the changelog from the commit log.

Already released it at https://modx.com/extras/package/assetmanager per the discussion in #68 